### PR TITLE
Print command line argument in the output file

### DIFF
--- a/main/com/quandarypeak/simian/SimianMain.java
+++ b/main/com/quandarypeak/simian/SimianMain.java
@@ -81,6 +81,10 @@ public class SimianMain {
             processFormatter(Option.PARAMETER_SEP + FormatterFactory.PLAIN);
         }
 
+        //print the whole commandline
+        LOG.println("Input arguments:");
+        LOG.println(String.join(" ", args));
+
         final Checker checker = new Checker(formatters.size() == 1 ? formatters.get(0) : new CompositeAuditListener(formatters), options);
 
         final CompositeFileFilter excludes = new CompositeFileFilter(this.excludes);


### PR DESCRIPTION
Print the command line argument in the output file. The Ruby script is picking up the line and outputting it to the result file. This is added to better preserve the execution record.